### PR TITLE
Fix stats file creation when stats collection off

### DIFF
--- a/src/data/collector.ts
+++ b/src/data/collector.ts
@@ -1,14 +1,17 @@
 import moment from "moment";
 import type { MetadataCache, TFile, Vault } from "obsidian";
+import type { BetterWordCountSettings } from "src/settings/settings";
 import { getCharacterCount, getSentenceCount, getWordCount } from "./stats";
 
 export class DataCollector {
   private vault: Vault;
   private metadataCache: MetadataCache;
+  private settings: BetterWordCountSettings;
 
-  constructor(vault: Vault, metadataCache: MetadataCache) {
+  constructor(vault: Vault, metadataCache: MetadataCache, settings: BetterWordCountSettings) {
     this.vault = vault;
     this.metadataCache = metadataCache;
+    this.settings = settings;
   }
 
   getTotalFileCount() {

--- a/src/main.ts
+++ b/src/main.ts
@@ -38,7 +38,8 @@ export default class BetterWordCount extends Plugin {
     if (this.settings.collectStats) {
       this.dataManager = new DataManager(
         this.app.vault,
-        this.app.metadataCache
+        this.app.metadataCache,
+        this.settings
       );
     }
 

--- a/src/status/manager.ts
+++ b/src/status/manager.ts
@@ -30,8 +30,8 @@ export class BarManager {
     this.statusBar = statusBar;
     this.settings = settings;
     this.vault = vault;
-    this.dataCollector = new DataCollector(vault, metadataCache);
-    this.dataManager = new DataManager(vault, metadataCache);
+    this.dataCollector = new DataCollector(vault, metadataCache, settings);
+    this.dataManager = new DataManager(vault, metadataCache, settings);
     this.deboucer = debounce(
       (text: string) => this.updateStatusBar(text),
       20,


### PR DESCRIPTION
I noticed that despite having collectStats set to false, upon vault or plugin load, the .vault-stats file would keep coming back. This is due to:

In the plugin onload(), a BarManager is created
In the BarManager constructor, a DataManager is created
In the DataManager constructor, the .vault-stats file is created and then written to, regardless of the user's collectStats setting.

We add an additional check in the DataManager constructor for the collectStats setting, propagating settings through constructors as necessary.

---

Thanks for developing and adding new features to this plugin, and I hope you're having a great holiday season!