### PR TITLE
Included warning about the legacy editor.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This plugin is the same as the built-in **Word Count** plugin, except when you s
 
 ![Better Count Word](https://raw.githubusercontent.com/lukeleppan/better-word-count/master/assets/better-word-count.gif)
 
+**Better Word Count may not work with the new Live-Preview Editor. Switch to the legacy editor in  Obsidian Settings > Editor > Use Legacy Editor.**
+
 ## Features
 
 - Allows you to store statistics about your vault.


### PR DESCRIPTION
The latest live-preview editor breaks the plugin. Added a warning for users in the README that they may need to switch to the legacy editor until support for the new editor is implemented.