### PR TITLE
Add basic filename filtering functionality

### DIFF
--- a/src/data/collector.ts
+++ b/src/data/collector.ts
@@ -1,14 +1,17 @@
 import moment from "moment";
 import type { MetadataCache, TFile, Vault } from "obsidian";
+import type { BetterWordCountSettings } from "src/settings/settings";
 import { getCharacterCount, getSentenceCount, getWordCount } from "./stats";
 
 export class DataCollector {
   private vault: Vault;
   private metadataCache: MetadataCache;
+  private settings: BetterWordCountSettings;
 
-  constructor(vault: Vault, metadataCache: MetadataCache) {
+  constructor(vault: Vault, metadataCache: MetadataCache, settings: BetterWordCountSettings) {
     this.vault = vault;
     this.metadataCache = metadataCache;
+    this.settings = settings;
   }
 
   getTotalFileCount() {

--- a/src/data/collector.ts
+++ b/src/data/collector.ts
@@ -18,12 +18,15 @@ export class DataCollector {
     return this.vault.getMarkdownFiles().length;
   }
 
+  fileFiltered(fileName: string){
+    return this.settings.fileNameFilter.length > 0 && fileName.includes(this.settings.fileNameFilter);
+  }
+
   async getTotalWordCount() {
     let words = 0;
-    const files = this.vault.getFiles();
-    for (const i in files) {
-      const file = files[i];
-      if (file.extension === "md") {
+    const files = this.vault.getMarkdownFiles();
+    for (const file of files) {
+      if (!this.fileFiltered(file.basename)) {
         words += getWordCount(await this.vault.cachedRead(file));
       }
     }
@@ -33,10 +36,9 @@ export class DataCollector {
 
   async getTotalCharacterCount() {
     let characters = 0;
-    const files = this.vault.getFiles();
-    for (const i in files) {
-      const file = files[i];
-      if (file.extension === "md") {
+    const files = this.vault.getMarkdownFiles();
+    for (const file of files) {
+      if (!this.fileFiltered(file.basename)) {
         characters += getCharacterCount(await this.vault.cachedRead(file));
       }
     }
@@ -45,15 +47,14 @@ export class DataCollector {
   }
 
   async getTotalSentenceCount() {
-    let sentence = 0;
-    const files = this.vault.getFiles();
-    for (const i in files) {
-      const file = files[i];
-      if (file.extension === "md") {
-        sentence += getSentenceCount(await this.vault.cachedRead(file));
+    let sentences = 0;
+    const files = this.vault.getMarkdownFiles();
+    for (const file of files) {
+      if (!this.fileFiltered(file.basename)) {
+        sentences += getSentenceCount(await this.vault.cachedRead(file));
       }
     }
 
-    return sentence;
+    return sentences;
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -38,7 +38,8 @@ export default class BetterWordCount extends Plugin {
     if (this.settings.collectStats) {
       this.dataManager = new DataManager(
         this.app.vault,
-        this.app.metadataCache
+        this.app.metadataCache,
+        this.settings
       );
     }
 

--- a/src/settings/settings-tab.ts
+++ b/src/settings/settings-tab.ts
@@ -48,6 +48,16 @@ export class BetterWordCountSettingsTab extends PluginSettingTab {
           await this.plugin.saveSettings();
         });
       });
+    new Setting(containerEl)
+      .setName("Filter Out Filenames")
+      .setDesc("Filenames including this string will be omitted from total counts. Leave blank to count all files.")
+      .addText((text) => {
+        text.setValue(this.plugin.settings.fileNameFilter)
+        text.onChange(async (value: string) => {
+          this.plugin.settings.fileNameFilter = value;
+          await this.plugin.saveSettings();
+        });
+      });
 
     // Status Bar Settings
     containerEl.createEl("h3", { text: "Status Bar Settings" });

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -10,6 +10,7 @@ export const DEFAULT_SETTINGS: BetterWordCountSettings = {
     "{file_count} files {total_word_count} words {total_character_count} characters",
   countComments: false,
   collectStats: false,
+  fileNameFilter: "",
 };
 
 export const PRESETS: PresetOption[] = [
@@ -38,6 +39,7 @@ export interface BetterWordCountSettings {
   statusBarAltQuery: string;
   countComments: boolean;
   collectStats: boolean;
+  fileNameFilter: string;
 }
 
 export interface PresetOption {

--- a/src/status/manager.ts
+++ b/src/status/manager.ts
@@ -30,8 +30,8 @@ export class BarManager {
     this.statusBar = statusBar;
     this.settings = settings;
     this.vault = vault;
-    this.dataCollector = new DataCollector(vault, metadataCache);
-    this.dataManager = new DataManager(vault, metadataCache);
+    this.dataCollector = new DataCollector(vault, metadataCache, settings);
+    this.dataManager = new DataManager(vault, metadataCache, settings);
     this.deboucer = debounce(
       (text: string) => this.updateStatusBar(text),
       20,


### PR DESCRIPTION
I have a vault with a lot of Excalidraw files. Ever since the Excalidraw plugin moved the file format to `.excalidraw.md` files, those Markdown files have been included in the total word count, inflating it. Though I do love seeing my word counts go to the moon, I do want to have an accurate total word count.

Adds a new setting fileNameFilter that omits filenames including that string from total word/character/sentence counts.

Includes change from #38. Closing that and marking this as a draft as this code builds upon 0.7.7, which was for the legacy editor (though anyone still using it can feel free to build and use this code).

Would love to see the rest of the stats tracking functionality make it to the live preview version of this plugin, and would be happy to either see this functionality added too or to rebase this against the live preview code when it's complete!