### PR TITLE
Protect against leaf not existing when obsidian first starts up.

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -72,7 +72,7 @@ export default class BetterWordCount extends Plugin {
 
   giveEditorPlugin(leaf: WorkspaceLeaf): void {
     //@ts-expect-error, not typed
-    const editor = leaf.view.editor;
+    const editor = leaf?.view?.editor;
     if (editor) {
       const editorView = editor.cm as EditorView;
       const editorPlug = editorView.plugin(editorPlugin);


### PR DESCRIPTION
I was getting "extension could not load error" on starting up obsidian. This was because the leaf argument was not an actual value (was null or undefined).