### PR TITLE
add a listener for the renamed event in `StatsManager`

### DIFF
--- a/src/stats/StatsManager.ts
+++ b/src/stats/StatsManager.ts
@@ -24,6 +24,12 @@ export default class StatsManager {
       false
     );
 
+    this.vault.on("rename", (new_name, old_path) => {
+      const content = this.vaultStats.modifiedFiles[old_path];
+      delete this.vaultStats.modifiedFiles[old_path];
+      this.vaultStats.modifiedFiles[new_name.path] = content;
+    });
+
     this.vault.adapter.exists(STATS_FILE).then(async (exists) => {
       if (!exists) {
         const vaultSt: VaultStatistics = {


### PR DESCRIPTION
This change avoids creating duplicate data in `vault-stats.json` when a file is renamed by copying the data from the old path to the new one.