### PR TITLE
Adding a space to the default suffix for the alt status bar

### DIFF
--- a/src/settings/Settings.ts
+++ b/src/settings/Settings.ts
@@ -62,7 +62,7 @@ export const DEFAULT_SETTINGS: BetterWordCountSettings = {
   altBar: [
     {
       prefix: "",
-      suffix: "files",
+      suffix: " files",
       metric: {
         type: MetricType.total,
         counter: MetricCounter.files,


### PR DESCRIPTION
The default suffix needs a space between the number and the actual word but it seems the reset button is already correctly configured