### PR TITLE
Allow better word count to correctly reflect selection count when using shift+home

### DIFF
--- a/src/editor/EditorPlugin.ts
+++ b/src/editor/EditorPlugin.ts
@@ -53,7 +53,6 @@ class EditorPlugin implements PluginValue {
       tr.isUserEvent("redo") ||
       tr.isUserEvent("select")
     ) {
-      console.log("OTHER EVENTS");
       const textIter = tr.newDoc.iter();
       let text = "";
       while (!textIter.done) {

--- a/src/editor/EditorPlugin.ts
+++ b/src/editor/EditorPlugin.ts
@@ -1,3 +1,4 @@
+import { Transaction } from "@codemirror/state";
 import {
   ViewUpdate,
   PluginValue,
@@ -22,9 +23,19 @@ class EditorPlugin implements PluginValue {
     }
 
     const tr = update.transactions[0];
-    if (!tr) return;
+
+    if (!tr) {
+      return;
+    }
+
+    // When selecting text with Shift+Home the userEventType is undefined.
+    // This is probably a bug in codemirror, for the time being doing an explict check
+    // for the type allows us to update the stats for the selection.
+    const userEventTypeUndefined =
+      tr.annotation(Transaction.userEvent) === undefined;
+
     if (
-      tr.isUserEvent("select") &&
+      (tr.isUserEvent("select") || userEventTypeUndefined) &&
       tr.newSelection.ranges[0].from !== tr.newSelection.ranges[0].to
     ) {
       let text = "";
@@ -42,6 +53,7 @@ class EditorPlugin implements PluginValue {
       tr.isUserEvent("redo") ||
       tr.isUserEvent("select")
     ) {
+      console.log("OTHER EVENTS");
       const textIter = tr.newDoc.iter();
       let text = "";
       while (!textIter.done) {


### PR DESCRIPTION
When selecting text with Shift+Home the userEventType is undefined.
This is probably a bug in code mirror (or whatever package is responsible for resolving event type), for the time being doing an explicit check for the type allows us to update the stats for the selection.