### PR TITLE
Add "Pages" option to tracked counts

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -33,7 +33,7 @@ export default class BetterWordCount extends Plugin {
 
     // Handle Statistics
     if (this.settings.collectStats) {
-      this.statsManager = new StatsManager(this.app.vault, this.app.workspace);
+      this.statsManager = new StatsManager(this.app.vault, this.app.workspace, this);
     }
 
     // Handle Status Bar

--- a/src/settings/Settings.ts
+++ b/src/settings/Settings.ts
@@ -2,6 +2,7 @@ export enum MetricCounter {
   words,
   characters,
   sentences,
+  pages,
   files,
 }
 
@@ -38,6 +39,7 @@ export interface BetterWordCountSettings {
   altBar: StatusBarItem[];
   countComments: boolean;
   collectStats: boolean;
+  pageWords: number;
 }
 
 export const DEFAULT_SETTINGS: BetterWordCountSettings = {
@@ -71,4 +73,5 @@ export const DEFAULT_SETTINGS: BetterWordCountSettings = {
   ],
   countComments: false,
   collectStats: false,
+  pageWords: 300,
 };

--- a/src/settings/SettingsTab.ts
+++ b/src/settings/SettingsTab.ts
@@ -37,6 +37,18 @@ export default class BetterWordCountSettingsTab extends PluginSettingTab {
           await this.plugin.saveSettings();
         });
       });
+    new Setting(containerEl)
+      .setName("Page Word Count")
+      .setDesc("Set how many words count as one \"page\"")
+      .addToggle((text: TextComponent) => {
+        text.inputEl.type = "number";
+        text.setPlaceholder("300");
+        text.setValue(this.plugin.settings.pageWords);
+        text.onChange(async (value) => {
+          this.plugin.settings.pageWords = value;
+          await this.plugin.saveSettings();
+      });
+    });
 
     // Status Bar Settings
     addStatusBarSettings(this.plugin, containerEl);

--- a/src/settings/SettingsTab.ts
+++ b/src/settings/SettingsTab.ts
@@ -44,8 +44,8 @@ export default class BetterWordCountSettingsTab extends PluginSettingTab {
         text.inputEl.type = "number";
         text.setPlaceholder("300");
         text.setValue(this.plugin.settings.pageWords);
-        text.onChange(async (value: number) => {
-          this.plugin.settings.pageWords = value;
+        text.onChange(async (value: string) => {
+          this.plugin.settings.pageWords = parseInt(value);
           await this.plugin.saveSettings();
       });
     });

--- a/src/settings/SettingsTab.ts
+++ b/src/settings/SettingsTab.ts
@@ -1,4 +1,4 @@
-import { App, PluginSettingTab, Setting, ToggleComponent } from "obsidian";
+import { App, PluginSettingTab, Setting, ToggleComponent, TextComponent } from "obsidian";
 import type BetterWordCount from "src/main";
 import { addStatusBarSettings } from "./StatusBarSettings";
 
@@ -40,11 +40,11 @@ export default class BetterWordCountSettingsTab extends PluginSettingTab {
     new Setting(containerEl)
       .setName("Page Word Count")
       .setDesc("Set how many words count as one \"page\"")
-      .addToggle((text: TextComponent) => {
+      .addText((text: TextComponent) => {
         text.inputEl.type = "number";
         text.setPlaceholder("300");
         text.setValue(this.plugin.settings.pageWords);
-        text.onChange(async (value) => {
+        text.onChange(async (value: number) => {
           this.plugin.settings.pageWords = value;
           await this.plugin.saveSettings();
       });

--- a/src/settings/SettingsTab.ts
+++ b/src/settings/SettingsTab.ts
@@ -43,7 +43,7 @@ export default class BetterWordCountSettingsTab extends PluginSettingTab {
       .addText((text: TextComponent) => {
         text.inputEl.type = "number";
         text.setPlaceholder("300");
-        text.setValue(this.plugin.settings.pageWords);
+        text.setValue(this.plugin.settings.pageWords.toString());
         text.onChange(async (value: string) => {
           this.plugin.settings.pageWords = parseInt(value);
           await this.plugin.saveSettings();

--- a/src/settings/StatusBarSettings.svelte
+++ b/src/settings/StatusBarSettings.svelte
@@ -18,6 +18,8 @@
           return "Chars in Note"
         case MetricCounter.sentences:
           return "Sentences in Note"
+        case MetricCounter.pages:
+          return "Pages in Note"
         case MetricCounter.files:
           return "Total Notes"
       }
@@ -29,6 +31,8 @@
           return "Daily Chars"
         case MetricCounter.sentences:
           return "Daily Sentences" 
+        case MetricCounter.pages:
+          return "Daily Pages"
         case MetricCounter.files:
           return "Total Notes"
       }
@@ -40,6 +44,8 @@
           return "Total Chars"
         case MetricCounter.sentences:
           return "Total Sentences"
+        case MetricCounter.pages:
+          return "Total Pages"
         case MetricCounter.files:
           return "Total Notes"
       }
@@ -181,6 +187,7 @@
             <option value={MetricCounter.words}>Words</option>
             <option value={MetricCounter.characters}>Characters</option>
             <option value={MetricCounter.sentences}>Sentences</option>
+            <option value={MetricCounter.pages}>Pages</option>
             <option value={MetricCounter.files}>Files</option>
          </select>
         </div>
@@ -348,6 +355,7 @@
             <option value={MetricCounter.words}>Words</option>
             <option value={MetricCounter.characters}>Characters</option>
             <option value={MetricCounter.sentences}>Sentences</option>
+            <option value={MetricCounter.pages}>Pages</option>
             <option value={MetricCounter.files}>Files</option>
          </select>
         </div>

--- a/src/stats/Stats.ts
+++ b/src/stats/Stats.ts
@@ -9,10 +9,12 @@ export interface Day {
   words: number;
   characters: number;
   sentences: number;
+  pages: number;
   files: number;
   totalWords: number;
   totalCharacters: number;
   totalSentences: number;
+  totalPages: number;
 }
 
 export type ModifiedFiles = Record<string, FileStat>;
@@ -21,6 +23,7 @@ export interface FileStat {
   words: CountDiff;
   characters: CountDiff;
   sentences: CountDiff;
+  pages: CountDiff;
 }
 
 export interface CountDiff {

--- a/src/stats/StatsManager.ts
+++ b/src/stats/StatsManager.ts
@@ -1,4 +1,5 @@
-import { debounce, Debouncer, TFile, Vault, Workspace, Plugin } from "obsidian";
+import { debounce, Debouncer, TFile, Vault, Workspace } from "obsidian";
+import type BetterWordCount from "../main";
 import { STATS_FILE } from "../constants";
 import type { Day, VaultStatistics } from "./Stats";
 import moment from "moment";
@@ -12,12 +13,12 @@ import {
 export default class StatsManager {
   private vault: Vault;
   private workspace: Workspace;
-  private plugin: Plugin;
+  private plugin: BetterWordCount;
   private vaultStats: VaultStatistics;
   private today: string;
   public debounceChange;
 
-  constructor(vault: Vault, workspace: Workspace, plugin: Plugin) {
+  constructor(vault: Vault, workspace: Workspace, plugin: BetterWordCount) {
     this.vault = vault;
     this.workspace = workspace;
     this.plugin = plugin;

--- a/src/stats/StatsManager.ts
+++ b/src/stats/StatsManager.ts
@@ -1,4 +1,4 @@
-import { debounce, Debouncer, TFile, Vault, Workspace } from "obsidian";
+import { debounce, Debouncer, TFile, Vault, Workspace, Plugin } from "obsidian";
 import { STATS_FILE } from "../constants";
 import type { Day, VaultStatistics } from "./Stats";
 import moment from "moment";

--- a/src/status/StatusBar.ts
+++ b/src/status/StatusBar.ts
@@ -107,6 +107,26 @@ export default class StatusBar {
                 : 0));
             break;
         }
+      } else if (metric.counter === MetricCounter.pages) {
+        switch (metric.type) {
+          case MetricType.file:
+            display = display + getPageCount(text, this.plugin.settings.pageWords);
+            break;
+          case MetricType.daily:
+            display =
+              display +
+              (this.plugin.settings.collectStats
+                ? this.plugin.statsManager.getDailyPages()
+                : 0);
+            break;
+          case MetricType.total:
+            display =
+              display +
+              (await (this.plugin.settings.collectStats
+                ? this.plugin.statsManager.getTotalPages()
+                : 0));
+            break;
+        }
       } else if (metric.counter === MetricCounter.files) {
         switch (metric.type) {
           case MetricType.file:
@@ -206,6 +226,26 @@ export default class StatusBar {
               display +
               (await (this.plugin.settings.collectStats
                 ? this.plugin.statsManager.getTotalSentences()
+                : 0));
+            break;
+        }
+      } else if (metric.counter === MetricCounter.pages) {
+        switch (metric.type) {
+          case MetricType.file:
+            display = display + 0;
+            break;
+          case MetricType.daily:
+            display =
+              display +
+              (this.plugin.settings.collectStats
+                ? this.plugin.statsManager.getDailyPages()
+                : 0);
+            break;
+          case MetricType.total:
+            display =
+              display +
+              (await (this.plugin.settings.collectStats
+                ? this.plugin.statsManager.getTotalPages()
                 : 0));
             break;
         }

--- a/src/status/StatusBar.ts
+++ b/src/status/StatusBar.ts
@@ -4,6 +4,7 @@ import {
   getWordCount,
   getCharacterCount,
   getSentenceCount,
+  getPageCount,
 } from "src/utils/StatUtils";
 import { debounce } from "obsidian";
 

--- a/src/utils/StatUtils.ts
+++ b/src/utils/StatUtils.ts
@@ -37,6 +37,10 @@ export function getSentenceCount(text: string): number {
   return sentences;
 }
 
+export function getPageCount(text: string, pageWords: number): number {
+  return parseFloat((getWordCount(text) / pageWords).toFixed(1));
+}
+
 export function getTotalFileCount(vault: Vault): number {
   return vault.getMarkdownFiles().length;
 }


### PR DESCRIPTION
Adds "Page" count tracking (alongside words, characters, and sentences), with a configurable number of words counting for each "page". I set a default value that, for plain text, is around an average double spaced page - but feel free to change it if implementing.

I also did not test this with anything that isn't the current-note tracking, because I don't use any of those other features - but in theory, they should work since I mostly reused existing code