### PR TITLE
Multi-window Support

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -12,12 +12,35 @@ import { settingsStore } from "./utils/SvelteStores";
 
 export default class BetterWordCount extends Plugin {
   public settings: BetterWordCountSettings;
-  public statusBar: StatusBar;
+
+  protected statusBars = new WeakMap<Window,StatusBar>();
+
+  public get statusBar(): StatusBar {
+    const win = activeWindow;
+    if (this.statusBars.has(win)) return this.statusBars.get(win);
+    const cls = "plugin-" + this.manifest.id.toLowerCase().replace(/[^_a-zA-Z0-9-]/, "-");
+    const container = win.document.querySelector("body > .app-container");
+    const statusBar = container.find(".status-bar") || container.createDiv("status-bar");
+    const statusBarEl = statusBar.find(".status-bar-item."+cls) ||
+        statusBar.createDiv(`status-bar-item ${cls.replace(/\./g,' ')}`);
+    const sb = new StatusBar(statusBarEl as HTMLElement, this);
+    sb.register(() => {
+      statusBarEl.detach();
+      if (win !== window) setTimeout(
+          () => {
+            if (!statusBar.hasChildNodes()) statusBar.detach();
+          }, 500   // allow for other unload operations to finish
+      )
+    });
+    this.addChild(sb);
+    this.statusBars.set(win, sb);
+    return sb;
+  };
+
   public statsManager: StatsManager;
 
   async onunload(): Promise<void> {
     this.statsManager = null;
-    this.statusBar = null;
   }
 
   async onload() {
@@ -35,10 +58,6 @@ export default class BetterWordCount extends Plugin {
     if (this.settings.collectStats) {
       this.statsManager = new StatsManager(this.app.vault, this.app.workspace, this);
     }
-
-    // Handle Status Bar
-    let statusBarEl = this.addStatusBarItem();
-    this.statusBar = new StatusBar(statusBarEl, this);
 
     // Handle the Editor Plugin
     this.registerEditorExtension(editorPlugin);

--- a/src/status/StatusBar.ts
+++ b/src/status/StatusBar.ts
@@ -9,14 +9,15 @@ import {
   getPageCount,
   cleanComments,
 } from "src/utils/StatUtils";
-import { debounce } from "obsidian";
+import { Component, debounce } from "obsidian";
 
-export default class StatusBar {
+export default class StatusBar extends Component {
   private statusBarEl: HTMLElement;
   private plugin: BetterWordCount;
   public debounceStatusBarUpdate;
 
   constructor(statusBarEl: HTMLElement, plugin: BetterWordCount) {
+    super();
     this.statusBarEl = statusBarEl;
     this.plugin = plugin;
     this.debounceStatusBarUpdate = debounce(
@@ -33,6 +34,13 @@ export default class StatusBar {
     );
   }
 
+  onload() {
+    this.registerEvent(this.plugin.app.workspace.on("window-close", (_, win) => {
+      // Discard when owning window is closed
+      if (this.statusBarEl.win === win) this.plugin.removeChild(this);
+    }))
+  }
+
   onClick(ev: MouseEvent) {
     ev;
   }
@@ -42,6 +50,8 @@ export default class StatusBar {
   }
 
   async updateStatusBar(text: string) {
+    if (text == null) return; // new window still loading
+
     const sb = this.plugin.settings.statusBar;
     let display = "";
 


### PR DESCRIPTION
This PR adds multi-window support (per #53), by creating a status bar item per window.  The approach used is the same used by Quick Explorer to add status bar items to other windows, in a way that allows multiple plugins to share these status bars.  (That is, such that the extra status bars will disappear when all plugins using them are disabled, and you can safely enable or disable such plugins in any order at any time.)