### PR TITLE
Add section counts next to headings

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "license": "MIT",
   "devDependencies": {
     "@codemirror/commands": "^6.1.2",
-    "@codemirror/language": "^6.3.0",
+    "@codemirror/language": "https://github.com/lishid/cm-language",
     "@codemirror/search": "^6.2.2",
     "@codemirror/state": "^6.1.2",
     "@codemirror/text": "^0.19.6",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -9,5 +9,5 @@ export const MATCH_HTML_COMMENT = new RegExp(
     "|<[?][^>]*>?",
   "g"
 );
-export const MATCH_COMMENT = new RegExp("%%[^%%]+%%", "g");
+export const MATCH_COMMENT = new RegExp("%%[\\s\\S]*?(?!%%)[\\s\\S]+?%%", "g");
 export const MATCH_PARAGRAPH = new RegExp("\n([^\n]+)\n", "g");

--- a/src/editor/EditorPlugin.ts
+++ b/src/editor/EditorPlugin.ts
@@ -192,6 +192,8 @@ class SectionWordCountEditorPlugin implements PluginValue {
       return match ? match[1].length : null;
     };
 
+    if (!view.visibleRanges.length) return b.finish();
+
     // Start processing from the beginning of the first visible range
     const { from } = view.visibleRanges[0];
     const doc = view.state.doc;

--- a/src/editor/EditorPlugin.ts
+++ b/src/editor/EditorPlugin.ts
@@ -86,12 +86,10 @@ interface SectionCountData {
 }
 
 class SectionWidget extends WidgetType {
-  plugin: BetterWordCount;
   data: SectionCountData;
 
-  constructor(plugin: BetterWordCount, data: SectionCountData) {
+  constructor(data: SectionCountData) {
     super();
-    this.plugin = plugin;
     this.data = data;
   }
 
@@ -298,7 +296,7 @@ class SectionWordCountEditorPlugin implements PluginValue {
         data.pos,
         Decoration.widget({
           side: 1,
-          widget: new SectionWidget(plugin, data),
+          widget: new SectionWidget(data),
         })
       );
     }

--- a/src/editor/EditorPlugin.ts
+++ b/src/editor/EditorPlugin.ts
@@ -1,32 +1,41 @@
-import { Transaction } from "@codemirror/state";
+import { RangeSetBuilder, StateEffect, StateField, Transaction } from "@codemirror/state";
 import {
   ViewUpdate,
   PluginValue,
   EditorView,
   ViewPlugin,
+  DecorationSet,
+  Decoration,
+  WidgetType,
 } from "@codemirror/view";
+import { App, HeadingCache, TFile, editorInfoField } from "obsidian";
 import type BetterWordCount from "src/main";
+import { getWordCount } from "src/utils/StatUtils";
 
-class EditorPlugin implements PluginValue {
-  hasPlugin: boolean;
+export const pluginField = StateField.define<BetterWordCount>({
+  create() {
+    return null;
+  },
+  update(state) {
+    return state;
+  },
+});
+
+class StatusBarEditorPlugin implements PluginValue {
   view: EditorView;
-  private plugin: BetterWordCount;
 
   constructor(view: EditorView) {
     this.view = view;
-    this.hasPlugin = false;
   }
 
   update(update: ViewUpdate): void {
-    if (!this.hasPlugin) {
-      return;
-    }
-
     const tr = update.transactions[0];
 
     if (!tr) {
       return;
     }
+
+    const plugin = update.view.state.field(pluginField);
 
     // When selecting text with Shift+Home the userEventType is undefined.
     // This is probably a bug in codemirror, for the time being doing an explict check
@@ -44,7 +53,7 @@ class EditorPlugin implements PluginValue {
       while (!textIter.done) {
         text = text + textIter.next().value;
       }
-      this.plugin.statusBar.debounceStatusBarUpdate(text);
+      plugin.statusBar.debounceStatusBarUpdate(text);
     } else if (
       tr.isUserEvent("input") ||
       tr.isUserEvent("delete") ||
@@ -58,19 +67,210 @@ class EditorPlugin implements PluginValue {
       while (!textIter.done) {
         text = text + textIter.next().value;
       }
-      if (tr.docChanged && this.plugin.statsManager) {
-        this.plugin.statsManager.debounceChange(text);
+      if (tr.docChanged && plugin.statsManager) {
+        plugin.statsManager.debounceChange(text);
       }
-      this.plugin.statusBar.debounceStatusBarUpdate(text);
+      plugin.statusBar.debounceStatusBarUpdate(text);
     }
-  }
-
-  addPlugin(plugin: BetterWordCount) {
-    this.plugin = plugin;
-    this.hasPlugin = true;
   }
 
   destroy() {}
 }
 
-export const editorPlugin = ViewPlugin.fromClass(EditorPlugin);
+export const statusBarEditorPlugin = ViewPlugin.fromClass(StatusBarEditorPlugin);
+
+interface HeadingRange {
+  heading: HeadingCache;
+  from: number;
+  to: number;
+}
+
+function getHeadingRanges(app: App, file: TFile, end: number) {
+  const fileCache = app.metadataCache.getFileCache(file);
+
+  if (!fileCache?.headings?.length) return null;
+
+  const nestedHeadings: HeadingCache[] = [];
+  const ranges: HeadingRange[] = [];
+
+  for (let i = 0, len = fileCache.headings.length; i < len; i++) {
+    const heading = fileCache.headings[i];
+    const lastHeading = nestedHeadings.last();
+    const isLast = i === len - 1;
+
+    if (!lastHeading || heading.level > lastHeading.level) {
+      // First heading, or traversing to higher level heading (eg ## -> ###)
+      nestedHeadings.push(heading);
+    } else if (heading.level === lastHeading.level) {
+      // Two headings of the same level
+      const nestedHeading = nestedHeadings.pop();
+      ranges.push({
+        heading: nestedHeading,
+        from: nestedHeading.position.end.offset,
+        to: heading.position.start.offset,
+      });
+      nestedHeadings.push(heading);
+    } else if (heading.level < lastHeading.level) {
+      // Traversing to lower level heading (eg. ### -> ##)
+      for (let j = nestedHeadings.length - 1; j >= 0; j--) {
+        const nestedHeading = nestedHeadings[j];
+
+        if (heading.level < nestedHeading.level) {
+          // Continue traversing to lower level heading
+          const nestedHeading = nestedHeadings.pop();
+          ranges.push({
+            heading: nestedHeading,
+            from: nestedHeading.position.end.offset,
+            to: heading.position.start.offset,
+          });
+          if (j === 0) {
+            nestedHeadings.push(heading);
+          }
+          continue;
+        }
+
+        if (heading.level === nestedHeading.level) {
+          // Stop because we found an equal level heading
+          const nestedHeading = nestedHeadings.pop();
+          ranges.push({
+            heading: nestedHeading,
+            from: nestedHeading.position.end.offset,
+            to: heading.position.start.offset,
+          });
+          nestedHeadings.push(heading);
+          break;
+        }
+
+        if (heading.level > nestedHeading.level) {
+          // Stop because we found an higher level heading
+          nestedHeadings.push(heading);
+          break;
+        }
+      }
+    } else if (isLast) {
+      // Final heading
+      nestedHeadings.push(heading);
+    }
+
+    if (isLast) {
+      // Flush the remaining headings
+      let nestedHeading: HeadingCache;
+      while ((nestedHeading = nestedHeadings.pop())) {
+        ranges.push({
+          heading: nestedHeading,
+          from: nestedHeading.position.end.offset,
+          to: end,
+        });
+      }
+    }
+  }
+
+  // Sort the headings in the order they appear in the document
+  ranges.sort((a, b) => a.from - b.from);
+
+  return ranges;
+}
+
+class SectionWidget extends WidgetType {
+  plugin: BetterWordCount;
+  range: HeadingRange;
+  count: number;
+  selfCount?: number;
+
+  constructor(plugin: BetterWordCount, range: HeadingRange, count: number, selfCount?: number) {
+    super();
+    this.plugin = plugin;
+    this.range = range;
+    this.count = count;
+    this.selfCount = selfCount;
+  }
+
+  eq(widget: this): boolean {
+    return this.range.from === widget.range.from && this.range.to === widget.range.to;
+  }
+
+  getDisplayText() {
+    if (this.selfCount) {
+      return `${this.selfCount} / ${this.count}`;
+    }
+    return this.count.toString();
+  }
+
+  toDOM() {
+    return createSpan({ cls: "bwc-section-count", text: this.getDisplayText() });
+  }
+}
+
+class SectionWordCountEditorPlugin implements PluginValue {
+  decorations: DecorationSet;
+
+  constructor(view: EditorView) {
+    this.decorations = this.mkDeco(view);
+  }
+
+  update(update: ViewUpdate) {
+    const plugin = update.view.state.field(pluginField);
+    if (!plugin.settings.displaySectionCounts) {
+      if (this.decorations.size) {
+        // Clear out any decorations
+        this.decorations = this.mkDeco(update.view);
+      }
+
+      return;
+    }
+
+    update.transactions.forEach((tr) => {
+      if (tr.effects.some((e) => e.is(metadataUpdated))) {
+        // If metadata has been updated, rebuild the decorations
+        this.decorations = this.mkDeco(update.view);
+      } else if (update.docChanged) {
+        // Otherwise just update their positions
+        this.decorations = this.decorations.map(tr.changes);
+      }
+    });
+  }
+
+  mkDeco(view: EditorView) {
+    const plugin = view.state.field(pluginField);
+    const b = new RangeSetBuilder<Decoration>();
+    if (!plugin.settings.displaySectionCounts) return b.finish();
+
+    const { app, file } = view.state.field(editorInfoField);
+    if (!file) return b.finish();
+
+    const headingRanges = getHeadingRanges(app, file, view.state.doc.length - 1);
+    if (!headingRanges?.length) return b.finish();
+
+    for (let i = 0; i < headingRanges.length; i++) {
+      const heading = headingRanges[i];
+      const next = headingRanges[i + 1];
+      const targetPos = heading.heading.position.end.offset;
+
+      const totalCount = getWordCount(view.state.doc.slice(heading.from, heading.to).toString());
+      let selfCount: number;
+
+      if (next && next.heading.level > heading.heading.level) {
+        const betweenCount = getWordCount(
+          view.state.doc.slice(heading.from, next.heading.position.start.offset).toString()
+        );
+        if (betweenCount) selfCount = betweenCount;
+      }
+
+      b.add(
+        targetPos,
+        targetPos,
+        Decoration.widget({
+          side: 0,
+          widget: new SectionWidget(plugin, heading, totalCount, selfCount),
+        })
+      );
+    }
+
+    return b.finish();
+  }
+}
+
+export const metadataUpdated = StateEffect.define<void>();
+export const sectionWordCountEditorPlugin = ViewPlugin.fromClass(SectionWordCountEditorPlugin, {
+  decorations: (v) => v.decorations,
+});

--- a/src/editor/EditorPlugin.ts
+++ b/src/editor/EditorPlugin.ts
@@ -40,8 +40,7 @@ class StatusBarEditorPlugin implements PluginValue {
     // When selecting text with Shift+Home the userEventType is undefined.
     // This is probably a bug in codemirror, for the time being doing an explict check
     // for the type allows us to update the stats for the selection.
-    const userEventTypeUndefined =
-      tr.annotation(Transaction.userEvent) === undefined;
+    const userEventTypeUndefined = tr.annotation(Transaction.userEvent) === undefined;
 
     if (
       (tr.isUserEvent("select") || userEventTypeUndefined) &&
@@ -171,36 +170,6 @@ function getHeadingRanges(app: App, file: TFile, end: number) {
   return ranges;
 }
 
-class SectionWidget extends WidgetType {
-  plugin: BetterWordCount;
-  range: HeadingRange;
-  count: number;
-  selfCount?: number;
-
-  constructor(plugin: BetterWordCount, range: HeadingRange, count: number, selfCount?: number) {
-    super();
-    this.plugin = plugin;
-    this.range = range;
-    this.count = count;
-    this.selfCount = selfCount;
-  }
-
-  eq(widget: this): boolean {
-    return this.range.from === widget.range.from && this.range.to === widget.range.to;
-  }
-
-  getDisplayText() {
-    if (this.selfCount) {
-      return `${this.selfCount} / ${this.count}`;
-    }
-    return this.count.toString();
-  }
-
-  toDOM() {
-    return createSpan({ cls: "bwc-section-count", text: this.getDisplayText() });
-  }
-}
-
 class SectionWordCountEditorPlugin implements PluginValue {
   decorations: DecorationSet;
 
@@ -244,7 +213,7 @@ class SectionWordCountEditorPlugin implements PluginValue {
     for (let i = 0; i < headingRanges.length; i++) {
       const heading = headingRanges[i];
       const next = headingRanges[i + 1];
-      const targetPos = heading.heading.position.end.offset;
+      const targetPos = heading.heading.position.start.offset;
 
       const totalCount = getWordCount(view.state.doc.slice(heading.from, heading.to).toString());
       let selfCount: number;
@@ -259,9 +228,11 @@ class SectionWordCountEditorPlugin implements PluginValue {
       b.add(
         targetPos,
         targetPos,
-        Decoration.widget({
-          side: 0,
-          widget: new SectionWidget(plugin, heading, totalCount, selfCount),
+        Decoration.line({
+          attributes: {
+            class: "bwc-section-count",
+            style: `--word-count: "${selfCount ? `${selfCount} / ${totalCount}` : totalCount.toString()}"`,
+          },
         })
       );
     }

--- a/src/settings/Settings.ts
+++ b/src/settings/Settings.ts
@@ -42,6 +42,7 @@ export interface BetterWordCountSettings {
   countComments: boolean;
   collectStats: boolean;
   pageWords: number;
+  displaySectionCounts: boolean;
 }
 
 export const DEFAULT_SETTINGS: BetterWordCountSettings = {
@@ -75,5 +76,6 @@ export const DEFAULT_SETTINGS: BetterWordCountSettings = {
   ],
   countComments: false,
   collectStats: false,
+  displaySectionCounts: false,
   pageWords: 300,
 };

--- a/src/settings/SettingsTab.ts
+++ b/src/settings/SettingsTab.ts
@@ -38,6 +38,17 @@ export default class BetterWordCountSettingsTab extends PluginSettingTab {
         });
       });
     new Setting(containerEl)
+      .setName("Display Section Word Count")
+      .setDesc("Turn on if you want to display section word counts next to headings.")
+      .addToggle((cb: ToggleComponent) => {
+        cb.setValue(this.plugin.settings.displaySectionCounts);
+        cb.onChange(async (value: boolean) => {
+          this.plugin.settings.displaySectionCounts = value;
+          this.plugin.onDisplaySectionCountsChange();
+          await this.plugin.saveSettings();
+        });
+      });
+    new Setting(containerEl)
       .setName("Page Word Count")
       .setDesc("Set how many words count as one \"page\"")
       .addText((text: TextComponent) => {

--- a/src/styles.css
+++ b/src/styles.css
@@ -20,20 +20,17 @@ details.bwc-sb-item-setting {
   margin-bottom: 0px;
 }
 
-.bwc-section-count {
+.bwc-section-count > span:last-of-type::after {
   background: var(--background-secondary);
   border-radius: var(--tag-radius);
   color: var(--text-muted);
+  content: var(--word-count);
   display: inline-flex;
   font-size: var(--font-ui-smaller);
   font-weight: var(--font-normal);
   line-height: 1;
-  margin: calc(-1 * var(--size-4-1)) 0 calc(-1 * var(--size-4-1)) var(--size-4-2);
+  margin: calc(-1 * var(--size-2-3)) 0 calc(-1 * var(--size-2-3)) var(--size-4-2);
   padding: var(--size-2-3) var(--size-4-2);
   position: relative;
-  top: calc(-1 * var(--size-2-1));
-}
-
-.cm-active .bwc-section-count {
-  display: none;
+  top: -3px;
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -20,7 +20,7 @@ details.bwc-sb-item-setting {
   margin-bottom: 0px;
 }
 
-.bwc-section-count > span:last-of-type::after {
+.bwc-section-count {
   background: var(--background-secondary);
   border-radius: var(--tag-radius);
   color: var(--text-muted);

--- a/src/styles.css
+++ b/src/styles.css
@@ -19,3 +19,20 @@ details.bwc-sb-item-setting {
 .bwc-status-bar-settings-title {
   margin-bottom: 0px;
 }
+
+.bwc-section-count {
+  background: var(--background-secondary);
+  border-radius: var(--tag-radius);
+  color: var(--text-muted);
+  display: inline-flex;
+  font-size: var(--font-ui-smaller);
+  font-weight: var(--font-normal);
+  margin: calc(-1 * var(--size-4-1)) 0 calc(-1 * var(--size-4-1)) var(--size-4-2);
+  padding: var(--size-4-1) var(--size-4-2);
+  position: relative;
+  top: calc(-1 * var(--size-2-1));
+}
+
+.cm-active .bwc-section-count {
+  display: none;
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -31,6 +31,7 @@ details.bwc-sb-item-setting {
   line-height: 1;
   margin: calc(-1 * var(--size-2-3)) 0 calc(-1 * var(--size-2-3)) var(--size-4-2);
   padding: var(--size-2-3) var(--size-4-2);
+  pointer-events: none;
   position: relative;
   top: -3px;
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -27,8 +27,9 @@ details.bwc-sb-item-setting {
   display: inline-flex;
   font-size: var(--font-ui-smaller);
   font-weight: var(--font-normal);
+  line-height: 1;
   margin: calc(-1 * var(--size-4-1)) 0 calc(-1 * var(--size-4-1)) var(--size-4-2);
-  padding: var(--size-4-1) var(--size-4-2);
+  padding: var(--size-2-3) var(--size-4-2);
   position: relative;
   top: calc(-1 * var(--size-2-1));
 }


### PR DESCRIPTION
This PR adds word counts next to headings. Currently it displays 2 counts. The first number is the number of words that belong only to the current heading. The second number is the total number of words under the current heading, including the word counts from any nested headings. In theory this fixes #58. What do you think?

My main questions are: do we like the format of `this count / total count`, and should these counts be configurable like the status bar?

<img width="735" alt="Screenshot 2023-07-16 at 3 04 07 PM" src="https://github.com/lukeleppan/better-word-count/assets/2694747/7a4ddba8-ec83-4054-9ad9-5b1a474a0109">
