### PR TITLE
Fix count comment negation

### DIFF
--- a/src/status/StatusBar.ts
+++ b/src/status/StatusBar.ts
@@ -45,7 +45,7 @@ export default class StatusBar {
     const sb = this.plugin.settings.statusBar;
     let display = "";
 
-    if (!this.plugin.settings.countComments) {
+    if (this.plugin.settings.countComments) {
       text = cleanComments(text);
     }
 


### PR DESCRIPTION
So, `settings.countComments` should actually be `settings.dontCountComments`

<img width="406" alt="Screenshot 2023-07-23 at 4 11 18 PM" src="https://github.com/lukeleppan/better-word-count/assets/2694747/25309073-5d40-4843-94fc-8f2f9baf8114">

but, I didn't want to change it and mess with people's settings.

This PR fixes an issue where, when this setting is toggled on, comments ARE counted, and when it is off they are not.