### PR TITLE
Expose API with counting and stats to other plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 *.iml
 .idea
 
+# VSCode
+.vscode
+
 # npm
 node_modules
 package-lock.json

--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "version": "0.10.0",
   "description": "Counts the words of selected text in the editor.",
   "main": "main.js",
+  "types": "src/api.d.ts",
+  "files": ["src/api.d.ts"],
   "scripts": {
     "lint": "svelte-check && eslint . --ext .ts",
     "dev": "rollup --config rollup.config.js -w",

--- a/src/api/api.d.ts
+++ b/src/api/api.d.ts
@@ -1,0 +1,15 @@
+import "obsidian";
+import type BetterWordCountApi from "./api";
+
+declare module "obsidian" {
+  interface App {
+    plugins: {
+      enabledPlugins: Set<string>;
+      plugins: {
+        ["better-word-count"]?: {
+          api: BetterWordCountApi;
+        };
+      };
+    };
+  }
+}

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1,0 +1,130 @@
+import { TFile, normalizePath } from "obsidian";
+import type BetterWordCount from "src/main";
+import { getCharacterCount, getCitationCount, getFootnoteCount, getPageCount, getSentenceCount, getWordCount } from "src/utils/StatUtils";
+
+export default class BetterWordCountApi {
+  private plugin: BetterWordCount;
+
+  constructor(plugin: BetterWordCount) {
+    this.plugin = plugin;
+  }
+
+  // plain utility functions
+  public getWordCount(text: string): number {
+    return getWordCount(text);
+  }
+  public getCharacterCount(text: string): number {
+    return getCharacterCount(text);
+  }
+  public getFootnoteCount(text: string): number {
+    return getFootnoteCount(text);
+  }
+  public getCitationCount(text: string): number {
+    return getCitationCount(text);
+  }
+  public getSentenceCount(text: string): number {
+    return getSentenceCount(text);
+  }
+  public getPageCount(text: string, pageWords: number = this.plugin.settings.pageWords): number {
+    return getPageCount(text, pageWords);
+  }
+
+  // Functions using page paths e.g. for use with dataviewjs
+  private async countPagePath(path: string, countFunc: (text: string) => number): Promise<number | null> {
+    const normalizedPath = normalizePath(path);
+    const file = this.plugin.app.vault.getAbstractFileByPath(normalizedPath);
+
+    // Check if it exists and is of the correct type
+    if (file instanceof TFile) {
+      const text = await this.plugin.app.vault.cachedRead(file);
+      return countFunc(text);
+    }
+
+    return null;
+  }
+
+  public async getWordCountPagePath(path: string): Promise<number | null> {
+    return this.countPagePath(path, getWordCount);
+  }
+  public getCharacterCountPagePath(path: string): Promise<number | null> {
+    return this.countPagePath(path, getCharacterCount);
+  }
+  public getFootnoteCountPagePath(path: string): Promise<number | null> {
+    return this.countPagePath(path, getFootnoteCount);
+  }
+  public getCitationCountPagePath(path: string): Promise<number | null> {
+    return this.countPagePath(path, getCitationCount);
+  }
+  public getSentenceCountPagePath(path: string): Promise<number | null> {
+    return this.countPagePath(path, getSentenceCount);
+  }
+  public getPageCountPagePath(path: string, pageWords: number = this.plugin.settings.pageWords): Promise<number | null> {
+    return this.countPagePath(path, (text: string) => getPageCount(text, pageWords));
+  }
+
+  // Functions for accessing stats
+  public getDailyWords(): number | null {
+    if (!this.plugin.statsManager) return null;
+    return this.plugin.statsManager.getDailyWords();
+  }
+
+  public getDailyCharacters(): number | null {
+    if (!this.plugin.statsManager) return null;
+    return this.plugin.statsManager.getDailyCharacters();
+  }
+
+  public getDailySentences(): number | null {
+    if (!this.plugin.statsManager) return null;
+    return this.plugin.statsManager.getDailySentences();
+  }
+
+  public getDailyFootnotes(): number | null {
+    if (!this.plugin.statsManager) return null;
+    return this.plugin.statsManager.getDailyFootnotes();
+  }
+
+  public getDailyCitations(): number | null {
+    if (!this.plugin.statsManager) return null;
+    return this.plugin.statsManager.getDailyCitations();
+  }
+
+  public getDailyPages(): number | null {
+    if (!this.plugin.statsManager) return null;
+    return this.plugin.statsManager.getDailyPages();
+  }
+
+  public getTotalFiles(): number | null {
+    if (!this.plugin.statsManager) return null;
+    return this.plugin.statsManager.getTotalFiles();
+  }
+
+  public async getTotalWords(): Promise<number | null> {
+    if (!this.plugin.statsManager) return null;
+    return this.plugin.statsManager.getTotalWords();
+  }
+
+  public async getTotalCharacters(): Promise<number | null> {
+    if (!this.plugin.statsManager) return null;
+    return this.plugin.statsManager.getTotalCharacters();
+  }
+
+  public async getTotalSentences(): Promise<number | null> {
+    if (!this.plugin.statsManager) return null;
+    return this.plugin.statsManager.getTotalSentences();
+  }
+
+  public async getTotalFootnotes(): Promise<number | null> {
+    if (!this.plugin.statsManager) return null;
+    return this.plugin.statsManager.getTotalFootnotes();
+  }
+
+  public async getTotalCitations(): Promise<number | null> {
+    if (!this.plugin.statsManager) return null;
+    return this.plugin.statsManager.getTotalCitations();
+  }
+
+  public async getTotalPages(): Promise<number | null> {
+    if (!this.plugin.statsManager) return null;
+    return this.plugin.statsManager.getTotalPages();
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,11 +11,13 @@ import {
 } from "./editor/EditorPlugin";
 import { BetterWordCountSettings, DEFAULT_SETTINGS } from "src/settings/Settings";
 import { settingsStore } from "./utils/SvelteStores";
+import BetterWordCountApi from "src/api/api";
 
 export default class BetterWordCount extends Plugin {
   public settings: BetterWordCountSettings;
   public statusBar: StatusBar;
   public statsManager: StatsManager;
+  public api: BetterWordCountApi = new BetterWordCountApi(this);
 
   async onunload(): Promise<void> {
     this.statsManager = null;

--- a/src/stats/StatsManager.ts
+++ b/src/stats/StatsManager.ts
@@ -119,7 +119,7 @@ export default class StatsManager {
     const currentCitations = getCitationCount(text);
     const currentFootnotes = getFootnoteCount(text);
     const currentPages = getPageCount(text, this.plugin.settings.pageWords);
-    
+
     if (
       this.vaultStats.history.hasOwnProperty(this.today) &&
       this.today === moment().format("YYYY-MM-DD")
@@ -139,7 +139,7 @@ export default class StatsManager {
           currentSentences - modFiles[fileName].citations.current;
         this.vaultStats.history[this.today].totalPages +=
           currentPages - modFiles[fileName].pages.current;
-         
+
         modFiles[fileName].words.current = currentWords;
         modFiles[fileName].characters.current = currentCharacters;
         modFiles[fileName].sentences.current = currentSentences;
@@ -276,7 +276,7 @@ export default class StatsManager {
     }
     return sentence;
   }
-  
+
   private async calcTotalPages(): Promise<number> {
     let pages = 0;
 
@@ -327,7 +327,6 @@ export default class StatsManager {
     return this.vaultStats.history[this.today].sentences;
   }
 
-
   public getDailyFootnotes(): number {
     return this.vaultStats.history[this.today].footnotes;
   }
@@ -357,7 +356,7 @@ export default class StatsManager {
     if (!this.vaultStats) return await this.calcTotalSentences();
     return this.vaultStats.history[this.today].totalSentences;
   }
-  
+
   public async getTotalFootnotes(): Promise<number> {
     if (!this.vaultStats) return await this.calcTotalFootnotes();
     return this.vaultStats.history[this.today].totalFootnotes;


### PR DESCRIPTION
Fixes #62.

This exposes an API that other plugins can access via `app.plugins.plugins["better-word-count"].api`.

The API reexports the utility functions from `StatUtils` to be able to count texts provided inside the code. For each of those functions it also exports a function that takes a file path instead of the text, e.g. for usage in dataview.

The API also exports a function for each public function in `StatsManager` that returns null if vault stats are deactivated (or statsManager is not yet initialized).

Here is a (tested) usage example with Dataview:
~~~
```dataviewjs
const bwc = app.plugins.plugins["better-word-count"].api;

dv.paragraph("Daily Characters: " + await bwc.getDailyCharacters());

dv.table(["Name", "Word Count", "Character Count"],
    await Promise.all(dv.pagePaths('#manuscript').values.map(async (pagePath) => {
        return [pagePath, await bwc.getWordCountPagePath(pagePath), await bwc.getCharacterCountPagePath(pagePath)]
    }))
);
```
~~~