### PR TITLE
Update StatUtils.ts for number formatting

### DIFF
--- a/src/utils/StatUtils.ts
+++ b/src/utils/StatUtils.ts
@@ -20,11 +20,12 @@ export function getWordCount(text: string): number {
     ].join("|"),
     "g"
   );
-  return (text.match(pattern) || []).length;
+  const result = (text.match(pattern) || []).length;
+  return formatNumber(result);
 }
 
 export function getCharacterCount(text: string): number {
-  return text.length;
+  return formatNumber(text.length);
 }
 
 export function getFootnoteCount(text: string): number {
@@ -34,14 +35,14 @@ export function getFootnoteCount(text: string): number {
   let overallFn = 0;
   if (regularFn) overallFn += regularFn.length;
   if (inlineFn) overallFn += inlineFn.length;
-  return overallFn;
+  return formatNumber(overallFn);
 }
 
 export function getCitationCount(text: string): number {
   const pandocCitations = text.match(/@[A-Za-z0-9-]+[,;\]](?!\()/gi);
   if (!pandocCitations) return 0;
   const uniqueCitations = [...new Set(pandocCitations)].length;
-  return uniqueCitations;
+  return formatNumber(uniqueCitations);
 }
 
 export function getSentenceCount(text: string): number {
@@ -50,8 +51,7 @@ export function getSentenceCount(text: string): number {
       /[^.!?\s][^.!?]*(?:[.!?](?!['"]?\s|$)[^.!?]*)*[.!?]?['"]?(?=\s|$)/gm
     ) || []
   ).length;
-
-  return sentences;
+  return formatNumber(sentences);
 }
 
 export function getPageCount(text: string, pageWords: number): number {
@@ -59,9 +59,21 @@ export function getPageCount(text: string, pageWords: number): number {
 }
 
 export function getTotalFileCount(vault: Vault): number {
-  return vault.getMarkdownFiles().length;
+  const fileCount = vault.getMarkdownFiles().length;
+  return formatNumber(fileCount);
 }
 
 export function cleanComments(text: string): string {
   return text.replace(MATCH_COMMENT, "").replace(MATCH_HTML_COMMENT, "");
+}
+
+// Removes floating point errors and adds thousands separators to a number.
+function formatNumber(number: number): string {
+  if (typeof Intl !== 'undefined' && typeof Intl.NumberFormat === 'function') {
+    // Use the user's local settings if available
+    return Math.round(number).toLocaleString();
+  } else {
+    // Default to 'en-US' otherwise
+    return Math.round(number).toLocaleString('en-US');
+  }
 }


### PR DESCRIPTION
I wrote a new function (formatNumber) that removes floating point errors and adds thousands separators to a number, and applied this function to the results of most numeric variables sent to StatusBar.ts

This should resolve at least two issues:
* https://github.com/lukeleppan/better-word-count/issues/103
* https://github.com/lukeleppan/better-word-count/issues/111

FYI: I haven't tested this change myself in Obsidian, so I may have missed something.