### PR TITLE
Add settings to disable counting of codeblocks and mermaid diagrams

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -11,3 +11,5 @@ export const MATCH_HTML_COMMENT = new RegExp(
 );
 export const MATCH_COMMENT = new RegExp("%%[\\s\\S]*?(?!%%)[\\s\\S]+?%%", "g");
 export const MATCH_PARAGRAPH = new RegExp("\n([^\n]+)\n", "g");
+export const MATCH_CODEBLOCK = new RegExp("```(?!mermaid)[\\s\\S]*?(?!```)[\\s\\S]+?```", "g")
+export const MATCH_MERMAID = new RegExp("```mermaid[\\s\\S]*?(?!```)[\\s\\S]+?```", "g")

--- a/src/settings/Settings.ts
+++ b/src/settings/Settings.ts
@@ -40,6 +40,8 @@ export interface BetterWordCountSettings {
   statusBar: StatusBarItem[];
   altBar: StatusBarItem[];
   countComments: boolean;
+  countCodeblocks: boolean;
+  countMermaid: boolean;
   collectStats: boolean;
   pageWords: number;
   displaySectionCounts: boolean;
@@ -75,6 +77,8 @@ export const DEFAULT_SETTINGS: BetterWordCountSettings = {
     },
   ],
   countComments: false,
+  countCodeblocks: false,
+  countMermaid: false,
   collectStats: false,
   displaySectionCounts: false,
   pageWords: 300,

--- a/src/settings/SettingsTab.ts
+++ b/src/settings/SettingsTab.ts
@@ -38,6 +38,26 @@ export default class BetterWordCountSettingsTab extends PluginSettingTab {
         });
       });
     new Setting(containerEl)
+        .setName("Don't Count Codeblocks")
+        .setDesc("Turn on if you don't want codeblocks to be counted. (Note: This does not turn off counting mermaid codeblocks)")
+        .addToggle((cb: ToggleComponent) => {
+            cb.setValue(this.plugin.settings.countCodeblocks);
+            cb.onChange(async (value: boolean) => {
+                this.plugin.settings.countCodeblocks = value;
+                await this.plugin.saveSettings();
+            });
+        });
+    new Setting(containerEl)
+        .setName("Don't Count Mermaid Diagrams")
+        .setDesc("Turn on if you don't want mermaid diagram codeblocks to be counted.")
+        .addToggle((cb: ToggleComponent) => {
+            cb.setValue(this.plugin.settings.countMermaid);
+            cb.onChange(async (value: boolean) => {
+                this.plugin.settings.countMermaid = value;
+                await this.plugin.saveSettings();
+            });
+        });
+    new Setting(containerEl)
       .setName("Display Section Word Count")
       .setDesc("Turn on if you want to display section word counts next to headings.")
       .addToggle((cb: ToggleComponent) => {

--- a/src/stats/StatsManager.ts
+++ b/src/stats/StatsManager.ts
@@ -10,7 +10,7 @@ import {
   getWordCount,
   getCitationCount,
   getFootnoteCount,
-  cleanComments,
+  cleanComments, cleanCodeblocks, cleanMermaid,
 } from "../utils/StatUtils";
 
 export default class StatsManager {
@@ -111,6 +111,12 @@ export default class StatsManager {
   public async change(text: string) {
     if (this.plugin.settings.countComments) {
       text = cleanComments(text);
+    }
+    if (this.plugin.settings.countCodeblocks) {
+      text = cleanCodeblocks(text);
+    }
+    if (this.plugin.settings.countMermaid) {
+      text = cleanMermaid(text);
     }
     const fileName = this.workspace.getActiveFile().path;
     const currentWords = getWordCount(text);

--- a/src/status/StatusBar.ts
+++ b/src/status/StatusBar.ts
@@ -7,7 +7,7 @@ import {
   getCitationCount,
   getFootnoteCount,
   getPageCount,
-  cleanComments,
+  cleanComments, cleanCodeblocks, cleanMermaid,
 } from "src/utils/StatUtils";
 import { debounce } from "obsidian";
 
@@ -47,6 +47,12 @@ export default class StatusBar {
 
     if (this.plugin.settings.countComments) {
       text = cleanComments(text);
+    }
+    if (this.plugin.settings.countCodeblocks) {
+      text = cleanCodeblocks(text);
+    }
+    if (this.plugin.settings.countMermaid) {
+      text = cleanMermaid(text);
     }
 
     for (let i = 0; i < sb.length; i++) {

--- a/src/utils/StatUtils.ts
+++ b/src/utils/StatUtils.ts
@@ -1,5 +1,5 @@
 import type { Vault } from "obsidian";
-import { MATCH_HTML_COMMENT, MATCH_COMMENT } from "src/constants";
+import {MATCH_HTML_COMMENT, MATCH_COMMENT, MATCH_CODEBLOCK, MATCH_MERMAID} from "src/constants";
 
 export function getWordCount(text: string): number {
   const spaceDelimitedChars =
@@ -64,4 +64,12 @@ export function getTotalFileCount(vault: Vault): number {
 
 export function cleanComments(text: string): string {
   return text.replace(MATCH_COMMENT, "").replace(MATCH_HTML_COMMENT, "");
+}
+
+export function cleanCodeblocks(text: string): string {
+  return text.replace(MATCH_CODEBLOCK, "");
+}
+
+export function cleanMermaid(text: string): string {
+  return text.replace(MATCH_MERMAID, "");
 }


### PR DESCRIPTION
This MR adds in the options to disable counting of codeblocks, and mermaid diagrams (as they by default still get counted, even though they result in an image)
This should close #98 

This is my first PR so feedback is more than welcome