### PR TITLE
Truncate daily counts on display

### DIFF
--- a/src/status/StatusBar.ts
+++ b/src/status/StatusBar.ts
@@ -164,14 +164,14 @@ export default class StatusBar {
             display =
               display +
               (this.plugin.settings.collectStats
-                ? this.plugin.statsManager.getDailyPages()
+                ? this.plugin.statsManager.getDailyPages().toFixed(1)
                 : 0);
             break;
           case MetricType.total:
             display =
               display +
               (await (this.plugin.settings.collectStats
-                ? this.plugin.statsManager.getTotalPages()
+                ? (await this.plugin.statsManager.getTotalPages()).toFixed(1)
                 : 0));
             break;
         }


### PR DESCRIPTION
Fixes #103

Just applies `Fixed()` to each `get__Pages()` result for the StatusBar, doesn't alter the counts themselves.

I'm not 100% sold on the exact code, especially needing to `await getTotalPages()` (even though its's needed because of the promise..) Happy to take feedback!