### PR TITLE
Change Statistics File To Use Pretty Printed JSON

### DIFF
--- a/src/stats/StatsManager.ts
+++ b/src/stats/StatsManager.ts
@@ -50,7 +50,7 @@ export default class StatsManager {
           history: {},
           modifiedFiles: {},
         };
-        await this.vault.adapter.write(this.plugin.settings.statsPath, JSON.stringify(vaultSt));
+        await this.vault.adapter.write(this.plugin.settings.statsPath, JSON.stringify(vaultSt, null, 2));
         this.vaultStats = JSON.parse(await this.vault.adapter.read(this.plugin.settings.statsPath));
       } else {
         this.vaultStats = JSON.parse(await this.vault.adapter.read(this.plugin.settings.statsPath));
@@ -59,7 +59,7 @@ export default class StatsManager {
             history: {},
             modifiedFiles: {},
           };
-          await this.vault.adapter.write(this.plugin.settings.statsPath, JSON.stringify(vaultSt));
+          await this.vault.adapter.write(this.plugin.settings.statsPath, JSON.stringify(vaultSt, null, 2));
         }
         this.vaultStats = JSON.parse(await this.vault.adapter.read(this.plugin.settings.statsPath));
       }
@@ -69,7 +69,7 @@ export default class StatsManager {
   }
 
   async update(): Promise<void> {
-    this.vault.adapter.write(this.plugin.settings.statsPath, JSON.stringify(this.vaultStats));
+    this.vault.adapter.write(this.plugin.settings.statsPath, JSON.stringify(this.vaultStats, null, 2));
   }
 
   async updateToday(): Promise<void> {


### PR DESCRIPTION
Very simple change. Just added a couple more parameters to where the plugin interacts with the JSON files.

The aim of this is to make it a little nicer to look at on the rare occasions when you do, and to hopefully help mitigate syncing conflicts better with git at least.