### PR TITLE
Fixes a words-counting incoordination issue. 

### DIFF
--- a/src/utils/StatUtils.ts
+++ b/src/utils/StatUtils.ts
@@ -14,7 +14,7 @@ export function getWordCount(text: string): number {
 
   const pattern = new RegExp(
     [
-      `(?:[0-9]+(?:(?:,|\\.)[0-9]+)*|[\\-${spaceDelimitedChars}])+`,
+      `(?:[0-9]+(?:(?:,|\\.)[0-9]+)*|[\\-${spaceDelimitedChars}0-9])+`,
       nonSpaceDelimitedWords,
       nonSpaceDelimitedWordsOther,
     ].join("|"),


### PR DESCRIPTION
With Obsidian core plugin, pattern like "abc123" will be considered as one word. 
![image](https://github.com/user-attachments/assets/291f8f28-ee0e-45a3-8936-545e0e3b6e9a) 

With current better word count plugin, pattern like "abc123" is counted as 2 words. 

Thus, add numbers into the pattern to coordinate words counting behavior with Obsidian core plugin. 